### PR TITLE
Update filebeat-daemonset.yaml

### DIFF
--- a/k8s/filebeat-daemonset.yaml
+++ b/k8s/filebeat-daemonset.yaml
@@ -49,6 +49,8 @@ data:
       enabled: true
       paths:
         - /home/VMadmin/FYP_microservices/PEAR_activity_service/logs/*.log
+      ignore_older: 24h 
 
+    logging.level: warning
     output.logstash:    
       hosts: ["192.168.188.184:5044"]


### PR DESCRIPTION
Editing filebeat-daemonset.yaml to reduce the amount of spam logs filebeat generates which is taking up space.