### PR TITLE
Fix false 404 error caused by querying soft deleted centre activity availability

### DIFF
--- a/app/crud/centre_activity_availability_crud.py
+++ b/app/crud/centre_activity_availability_crud.py
@@ -228,7 +228,7 @@ def update_centre_activity_availability(
         db.rollback()
         raise HTTPException(status_code = 500, detail = f"Error updating Centre Activity Availability: {str(e)}") from e
 
-    centre_activity = get_centre_activity_availability_by_id(db, centre_activity_availability_data.centre_activity_id)
+    centre_activity = db_centre_activity_availability.centre_activity
     activity_name = centre_activity.activity.title if centre_activity and centre_activity.activity else "Unknown"
 
     log_crud_action(

--- a/app/crud/centre_activity_availability_crud.py
+++ b/app/crud/centre_activity_availability_crud.py
@@ -271,7 +271,7 @@ def delete_centre_activity_availability(
     
     original_data_dict = serialize_data(model_to_dict(db_centre_activity_availability))
 
-    centre_activity = get_centre_activity_availability_by_id(db, db_centre_activity_availability.centre_activity_id)
+    centre_activity = db_centre_activity_availability.centre_activity
     activity_name = centre_activity.activity.title if centre_activity and centre_activity.activity else "Unknown"
 
     log_crud_action(


### PR DESCRIPTION
## Summary
This PR fixes an incorrect 404 error returned when updating/deleting Centre Activity Availability.

## Problem
Updating/Deleting a Centre Activity Availbility will return:
```json
HTTP Error 404
Response body:
{
    "detail": "Centre Activity Availability not found or already soft deleted."
}
```
This happened even when the update/delete operation itself was valid.

## Cause
After executing the update/delete operation, the code uses the `get_centre_activity_availability_by_id(db, centre_activity_availability_id, include_deleted)` function to query the updated record for its corresponding centre activity. The errors are caused by the following:

1. In the update operation, the `centre_activity_id` is passed into the function argument instead of the correct `centre_activity_availability_id`. As a result, it looks for a centre activity availability using the wrong id, which may not exist.
2. In the delete operation, the `include_deleted` flag is not passed in, and defaults to False. As a result, it does not return the soft deleted availability record.

In both cases, a 404 error is raised.

## Changes
Replace the `get_centre_activity_availability_by_id` functions with existing `db_centre_activity_availability` variable that already exist.