### PR TITLE
Add aggregated endpoints for activity preference and exclusion tables

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.models import(
 
 from app.routers import(
     auth_router,
+    aggregated_router,
     centre_activity_exclusion_router,
     centre_activity_router,
     activity_router,
@@ -217,6 +218,7 @@ routers = [
     (routine_router.router, f"{API_VERSION_PREFIX}/routines", ["Routines"]),
     (routine_exclusion_router.router, f"{API_VERSION_PREFIX}/routine_exclusions", ["Routine Exclusions"]),
     (integrity_router.router, f"{API_VERSION_PREFIX}/integrity", ["Integrity"]),
+    (aggregated_router.router, f"{API_VERSION_PREFIX}/aggregated", ["Aggregated"]),
 ]
 
 # Add auth router separately (without API version prefix for OAuth2 compatibility)

--- a/app/routers/aggregated_router.py
+++ b/app/routers/aggregated_router.py
@@ -1,0 +1,65 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+from app.database import get_db
+from app.auth.jwt_utils import get_current_user, JWTPayload
+from app.schemas.aggregated_schema import ActivityPreferenceTableData, ActivityExclusionTableData
+import app.crud.activity_crud as activity_crud
+import app.crud.centre_activity_crud as centre_activity_crud
+import app.crud.centre_activity_preference_crud as preference_crud
+import app.crud.centre_activity_recommendation_crud as recommendation_crud
+import app.crud.centre_activity_exclusion_crud as exclusion_crud
+import app.crud.ref_patient_crud as patient_crud
+from typing import Optional
+
+router = APIRouter()
+
+
+@router.get("/activity-preference-table", response_model=ActivityPreferenceTableData)
+def get_activity_preference_table_data(
+    db: Session = Depends(get_db),
+    current_user: Optional[JWTPayload] = Depends(get_current_user),
+    include_deleted: bool = Query(False),
+):
+    activities = activity_crud.get_activities(db=db, include_deleted=include_deleted)
+    centre_activities = centre_activity_crud.get_centre_activities(db=db, include_deleted=include_deleted)
+    preferences = preference_crud.get_centre_activity_preferences(db=db, include_deleted=include_deleted)
+    recommendations = recommendation_crud.get_all_centre_activity_recommendations(
+        db=db,
+        current_user_info={
+            "id": current_user.userId if current_user else None,
+            "role_name": current_user.roleName if current_user else None,
+            "fullname": current_user.fullName if current_user else None,
+            "bearer_token": ""
+        },
+        include_deleted=include_deleted
+    )
+    exclusions = exclusion_crud.get_centre_activity_exclusions(db=db, include_deleted=include_deleted)
+    patients, _, _ = patient_crud.get_ref_patients(db=db, page_no=0, page_size=10000)
+
+    return ActivityPreferenceTableData(
+        activities=activities,
+        centre_activities=centre_activities,
+        preferences=preferences,
+        recommendations=recommendations,
+        exclusions=exclusions,
+        patients=patients,
+    )
+
+
+@router.get("/activity-exclusion-table", response_model=ActivityExclusionTableData)
+def get_activity_exclusion_table_data(
+    db: Session = Depends(get_db),
+    current_user: Optional[JWTPayload] = Depends(get_current_user),
+    include_deleted: bool = Query(False),
+):
+    activities = activity_crud.get_activities(db=db, include_deleted=include_deleted)
+    centre_activities = centre_activity_crud.get_centre_activities(db=db, include_deleted=include_deleted)
+    exclusions = exclusion_crud.get_centre_activity_exclusions(db=db, include_deleted=include_deleted)
+    patients, _, _ = patient_crud.get_ref_patients(db=db, page_no=0, page_size=10000)
+
+    return ActivityExclusionTableData(
+        activities=activities,
+        centre_activities=centre_activities,
+        exclusions=exclusions,
+        patients=patients,
+    )

--- a/app/schemas/aggregated_schema.py
+++ b/app/schemas/aggregated_schema.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+from typing import List
+from app.schemas.activity_schema import ActivityRead
+from app.schemas.centre_activity_schema import CentreActivityResponse
+from app.schemas.centre_activity_preference_schema import CentreActivityPreferenceResponse
+from app.schemas.centre_activity_recommendation_schema import CentreActivityRecommendationResponse
+from app.schemas.centre_activity_exclusion_schema import CentreActivityExclusionResponse
+from app.schemas.ref_patient import RefPatient
+
+
+class ActivityPreferenceTableData(BaseModel):
+    activities: List[ActivityRead]
+    centre_activities: List[CentreActivityResponse]
+    preferences: List[CentreActivityPreferenceResponse]
+    recommendations: List[CentreActivityRecommendationResponse]
+    exclusions: List[CentreActivityExclusionResponse]
+    patients: List[RefPatient]
+
+
+class ActivityExclusionTableData(BaseModel):
+    activities: List[ActivityRead]
+    centre_activities: List[CentreActivityResponse]
+    exclusions: List[CentreActivityExclusionResponse]
+    patients: List[RefPatient]

--- a/tests/unit/test_aggregated.py
+++ b/tests/unit/test_aggregated.py
@@ -1,0 +1,328 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime, date
+from sqlalchemy.orm import Session
+
+from app.routers.aggregated_router import (
+    get_activity_preference_table_data,
+    get_activity_exclusion_table_data,
+)
+from app.schemas.aggregated_schema import ActivityPreferenceTableData, ActivityExclusionTableData
+from app.schemas.activity_schema import ActivityRead
+from app.schemas.centre_activity_schema import CentreActivityResponse
+from app.schemas.centre_activity_preference_schema import CentreActivityPreferenceResponse
+from app.schemas.centre_activity_recommendation_schema import CentreActivityRecommendationResponse
+from app.schemas.centre_activity_exclusion_schema import CentreActivityExclusionResponse
+from app.schemas.ref_patient import RefPatient
+
+
+@pytest.fixture
+def mock_db():
+    return MagicMock(spec=Session)
+
+
+@pytest.fixture
+def sample_activity():
+    return ActivityRead(
+        id=1,
+        title="Test Activity",
+        description="Test description",
+        is_deleted=False,
+        created_date=datetime.now(),
+        modified_date=datetime.now(),
+        created_by_id="user1",
+        modified_by_id=None,
+    )
+
+
+@pytest.fixture
+def sample_centre_activity():
+    return CentreActivityResponse(
+        id=1,
+        activity_id=1,
+        is_compulsory=False,
+        is_fixed=True,
+        is_group=False,
+        start_date=date.today(),
+        end_date=date(2999, 12, 31),
+        min_duration=60,
+        max_duration=60,
+        min_people_req=1,
+        fixed_time_slots=None,
+        is_deleted=False,
+        created_date=datetime.now(),
+        modified_date=None,
+        created_by_id="user1",
+        modified_by_id=None,
+    )
+
+
+@pytest.fixture
+def sample_preference():
+    return CentreActivityPreferenceResponse(
+        id=1,
+        centre_activity_id=1,
+        patient_id=1,
+        is_like=1,
+        is_deleted=False,
+        created_date=datetime.now(),
+        modified_date=None,
+        created_by_id="user1",
+        modified_by_id=None,
+    )
+
+
+@pytest.fixture
+def sample_recommendation():
+    return CentreActivityRecommendationResponse(
+        id=1,
+        centre_activity_id=1,
+        patient_id=1,
+        doctor_recommendation=1,
+        doctor_remarks=None,
+        is_deleted=False,
+        doctor_id="doc1",
+        created_date=datetime.now(),
+        modified_date=None,
+        created_by_id="user1",
+        modified_by_id=None,
+    )
+
+
+@pytest.fixture
+def sample_exclusion():
+    return CentreActivityExclusionResponse(
+        id=1,
+        centre_activity_id=1,
+        patient_id=1,
+        exclusion_remarks=None,
+        start_date=date.today(),
+        end_date=None,
+        is_deleted=False,
+        created_date=datetime.now(),
+        modified_date=datetime.now(),
+        created_by_id="user1",
+        modified_by_id=None,
+    )
+
+
+@pytest.fixture
+def sample_patient():
+    return RefPatient(
+        id=1,
+        name="Test Patient",
+        preferred_name=None,
+        update_bit="1",
+        start_date=datetime.now(),
+        end_date=None,
+        is_active="1",
+        is_deleted="0",
+        created_date=datetime.now(),
+        modified_date=datetime.now(),
+        created_by_id="user1",
+        modified_by_id="user1",
+    )
+
+
+# ===== activity-preference-table =====
+
+@patch("app.crud.ref_patient_crud.get_ref_patients")
+@patch("app.crud.centre_activity_exclusion_crud.get_centre_activity_exclusions")
+@patch("app.crud.centre_activity_recommendation_crud.get_all_centre_activity_recommendations")
+@patch("app.crud.centre_activity_preference_crud.get_centre_activity_preferences")
+@patch("app.crud.centre_activity_crud.get_centre_activities")
+@patch("app.crud.activity_crud.get_activities")
+def test_get_activity_preference_table_returns_all_fields(
+    mock_get_activities,
+    mock_get_centre_activities,
+    mock_get_preferences,
+    mock_get_recommendations,
+    mock_get_exclusions,
+    mock_get_patients,
+    mock_db,
+    mock_supervisor_jwt,
+    sample_activity,
+    sample_centre_activity,
+    sample_preference,
+    sample_recommendation,
+    sample_exclusion,
+    sample_patient,
+):
+    mock_get_activities.return_value = [sample_activity]
+    mock_get_centre_activities.return_value = [sample_centre_activity]
+    mock_get_preferences.return_value = [sample_preference]
+    mock_get_recommendations.return_value = [sample_recommendation]
+    mock_get_exclusions.return_value = [sample_exclusion]
+    mock_get_patients.return_value = ([sample_patient], 1, 1)
+
+    result = get_activity_preference_table_data(
+        db=mock_db,
+        current_user=mock_supervisor_jwt,
+        include_deleted=False,
+    )
+
+    assert isinstance(result, ActivityPreferenceTableData)
+    assert len(result.activities) == 1
+    assert len(result.centre_activities) == 1
+    assert len(result.preferences) == 1
+    assert len(result.recommendations) == 1
+    assert len(result.exclusions) == 1
+    assert len(result.patients) == 1
+
+
+@patch("app.crud.ref_patient_crud.get_ref_patients")
+@patch("app.crud.centre_activity_exclusion_crud.get_centre_activity_exclusions")
+@patch("app.crud.centre_activity_recommendation_crud.get_all_centre_activity_recommendations")
+@patch("app.crud.centre_activity_preference_crud.get_centre_activity_preferences")
+@patch("app.crud.centre_activity_crud.get_centre_activities")
+@patch("app.crud.activity_crud.get_activities")
+def test_get_activity_preference_table_empty_data(
+    mock_get_activities,
+    mock_get_centre_activities,
+    mock_get_preferences,
+    mock_get_recommendations,
+    mock_get_exclusions,
+    mock_get_patients,
+    mock_db,
+    mock_supervisor_jwt,
+):
+    mock_get_activities.return_value = []
+    mock_get_centre_activities.return_value = []
+    mock_get_preferences.return_value = []
+    mock_get_recommendations.return_value = []
+    mock_get_exclusions.return_value = []
+    mock_get_patients.return_value = ([], 0, 0)
+
+    result = get_activity_preference_table_data(
+        db=mock_db,
+        current_user=mock_supervisor_jwt,
+        include_deleted=False,
+    )
+
+    assert isinstance(result, ActivityPreferenceTableData)
+    assert result.activities == []
+    assert result.preferences == []
+    assert result.recommendations == []
+    assert result.exclusions == []
+    assert result.patients == []
+
+
+@patch("app.crud.ref_patient_crud.get_ref_patients")
+@patch("app.crud.centre_activity_exclusion_crud.get_centre_activity_exclusions")
+@patch("app.crud.centre_activity_recommendation_crud.get_all_centre_activity_recommendations")
+@patch("app.crud.centre_activity_preference_crud.get_centre_activity_preferences")
+@patch("app.crud.centre_activity_crud.get_centre_activities")
+@patch("app.crud.activity_crud.get_activities")
+def test_get_activity_preference_table_no_auth(
+    mock_get_activities,
+    mock_get_centre_activities,
+    mock_get_preferences,
+    mock_get_recommendations,
+    mock_get_exclusions,
+    mock_get_patients,
+    mock_db,
+):
+    mock_get_activities.return_value = []
+    mock_get_centre_activities.return_value = []
+    mock_get_preferences.return_value = []
+    mock_get_recommendations.return_value = []
+    mock_get_exclusions.return_value = []
+    mock_get_patients.return_value = ([], 0, 0)
+
+    result = get_activity_preference_table_data(
+        db=mock_db,
+        current_user=None,
+        include_deleted=False,
+    )
+
+    assert isinstance(result, ActivityPreferenceTableData)
+
+
+# ===== activity-exclusion-table =====
+
+@patch("app.crud.ref_patient_crud.get_ref_patients")
+@patch("app.crud.centre_activity_exclusion_crud.get_centre_activity_exclusions")
+@patch("app.crud.centre_activity_crud.get_centre_activities")
+@patch("app.crud.activity_crud.get_activities")
+def test_get_activity_exclusion_table_returns_all_fields(
+    mock_get_activities,
+    mock_get_centre_activities,
+    mock_get_exclusions,
+    mock_get_patients,
+    mock_db,
+    mock_supervisor_jwt,
+    sample_activity,
+    sample_centre_activity,
+    sample_exclusion,
+    sample_patient,
+):
+    mock_get_activities.return_value = [sample_activity]
+    mock_get_centre_activities.return_value = [sample_centre_activity]
+    mock_get_exclusions.return_value = [sample_exclusion]
+    mock_get_patients.return_value = ([sample_patient], 1, 1)
+
+    result = get_activity_exclusion_table_data(
+        db=mock_db,
+        current_user=mock_supervisor_jwt,
+        include_deleted=False,
+    )
+
+    assert isinstance(result, ActivityExclusionTableData)
+    assert len(result.activities) == 1
+    assert len(result.centre_activities) == 1
+    assert len(result.exclusions) == 1
+    assert len(result.patients) == 1
+
+
+@patch("app.crud.ref_patient_crud.get_ref_patients")
+@patch("app.crud.centre_activity_exclusion_crud.get_centre_activity_exclusions")
+@patch("app.crud.centre_activity_crud.get_centre_activities")
+@patch("app.crud.activity_crud.get_activities")
+def test_get_activity_exclusion_table_empty_data(
+    mock_get_activities,
+    mock_get_centre_activities,
+    mock_get_exclusions,
+    mock_get_patients,
+    mock_db,
+    mock_supervisor_jwt,
+):
+    mock_get_activities.return_value = []
+    mock_get_centre_activities.return_value = []
+    mock_get_exclusions.return_value = []
+    mock_get_patients.return_value = ([], 0, 0)
+
+    result = get_activity_exclusion_table_data(
+        db=mock_db,
+        current_user=mock_supervisor_jwt,
+        include_deleted=False,
+    )
+
+    assert isinstance(result, ActivityExclusionTableData)
+    assert result.activities == []
+    assert result.exclusions == []
+    assert result.patients == []
+
+
+@patch("app.crud.ref_patient_crud.get_ref_patients")
+@patch("app.crud.centre_activity_exclusion_crud.get_centre_activity_exclusions")
+@patch("app.crud.centre_activity_crud.get_centre_activities")
+@patch("app.crud.activity_crud.get_activities")
+def test_get_activity_exclusion_table_no_auth(
+    mock_get_activities,
+    mock_get_centre_activities,
+    mock_get_exclusions,
+    mock_get_patients,
+    mock_db,
+):
+    mock_get_activities.return_value = []
+    mock_get_centre_activities.return_value = []
+    mock_get_exclusions.return_value = []
+    mock_get_patients.return_value = ([], 0, 0)
+
+    result = get_activity_exclusion_table_data(
+        db=mock_db,
+        current_user=None,
+        include_deleted=False,
+    )
+
+    assert isinstance(result, ActivityExclusionTableData)


### PR DESCRIPTION

- Added two aggregated GET endpoints under  to reduce frontend API calls for table views
-  returns activities, centre activities, preferences, recommendations, exclusions and patients in a single call
-  returns activities, centre activities, exclusions and patients in a single call
- Added unit tests for both endpoints (6 tests, all passing)


