### PR TITLE
Point Filebeat at the working Elasticsearch host, not the dead one

### DIFF
--- a/k8s/filebeat-daemonset.yaml
+++ b/k8s/filebeat-daemonset.yaml
@@ -52,5 +52,5 @@ data:
       ignore_older: 24h 
 
     logging.level: warning
-    output.logstash:    
-      hosts: ["192.168.188.184:5044"]
+    output.logstash:
+      hosts: ["192.168.188.172:5044"]


### PR DESCRIPTION
Same issue confirmed and fixed for Patient service (see that repo's matching commit): Filebeat was shipping to 192.168.188.184:5044, whose Logstash has been continuously failing to reach its own Elasticsearch (inactive/disabled service there). 192.168.188.172 hosts a live, working Elasticsearch + Logstash instead 