### PR TITLE
Watch both production and staging log directories, not just production

### DIFF
--- a/k8s/filebeat-daemonset.yaml
+++ b/k8s/filebeat-daemonset.yaml
@@ -25,14 +25,19 @@ spec:
           mountPath: /etc/filebeat.yml
           subPath: filebeat.yml
         - name: logs
-          mountPath: /home/VMadmin/FYP_microservices/PEAR_activity_service/logs
+          mountPath: /home/VMadmin/FYP_microservices
       volumes:
       - name: config
         configMap:
           name: filebeat-config
       - name: logs
         hostPath:
-          path: /home/VMadmin/FYP_microservices/PEAR_activity_service/logs
+          # Mounts the shared parent directory rather than one specific
+          # service directory, because production and staging write to two
+          # different sibling directories on this box (PEAR_activity_service
+          # vs PEAR_activity_service_stg) -- see filebeat.inputs.paths below
+          # for the specific subdirectories actually watched.
+          path: /home/VMadmin/FYP_microservices
 
 
 # Define ConfigMap for Filebeat configuration
@@ -49,7 +54,8 @@ data:
       enabled: true
       paths:
         - /home/VMadmin/FYP_microservices/PEAR_activity_service/logs/*.log
-      ignore_older: 24h 
+        - /home/VMadmin/FYP_microservices/PEAR_activity_service_stg/logs/*.log
+      ignore_older: 24h
 
     logging.level: warning
     output.logstash:


### PR DESCRIPTION
The previous config only watched
/home/VMadmin/FYP_microservices/PEAR_activity_service/logs (production), confirmed from the live deployment manifest. Staging writes to a separate sibling directory,
/home/VMadmin/FYP_microservices/PEAR_activity_service_stg/logs (also confirmed from the live staging deployment manifest), which was never watched at all -- so no staging activity has ever reached Elasticsearch, independent of the Logstash host fix in the previous commit.

Mounts the shared parent directory and watches both subdirectories explicitly, since a single DaemonSet hostPath can only mount one host path per node.