### PR TITLE
Add explicit filestream input ID to stop Filebeat erroring out silently

### DIFF
--- a/k8s/filebeat-daemonset.yaml
+++ b/k8s/filebeat-daemonset.yaml
@@ -51,6 +51,7 @@ data:
   filebeat.yml: |-
     filebeat.inputs:
     - type: filestream
+      id: activity-service-logs
       enabled: true
       paths:
         - /home/VMadmin/FYP_microservices/PEAR_activity_service/logs/*.log


### PR DESCRIPTION
FIlebeat currently has no explicit unique id, adding it in in this PR