### PR TITLE
perf: remove unnecessary secrets from unit test CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,24 +10,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    environment: ${{ github.base_ref == 'main' && 'prod' || 'staging' }}
     env:
-      SERVICE_NAME: ${{ vars.SERVICE_NAME }}
-      DB_SERVER: ${{ secrets.DB_SERVER }}
-      DB_DATABASE: ${{ secrets.DB_DATABASE }}
-      DB_DATABASE_PORT: ${{ secrets.DB_DATABASE_PORT }}
-      DB_USERNAME: ${{ secrets.DB_USERNAME }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      DB_DRIVER: ${{ secrets.DB_DRIVER }}
-      WEB_FE_ORIGIN: ${{ secrets.WEB_FE_ORIGIN }}
-      WEB_FE_ORIGIN_STG: ${{ secrets.WEB_FE_ORIGIN_STG }}   # To be shifted into Environment Secrets with _STG removed when Activity stg server is up
-      PATIENT_BE_ORIGIN: ${{ secrets.PATIENT_BE_ORIGIN }}
-      USER_BE_ORIGIN: ${{ secrets.USER_BE_ORIGIN }}
-      RABBITMQ_HOST: ${{ secrets.RABBITMQ_HOST }}
-      RABBITMQ_PORT: ${{ secrets.RABBITMQ_PORT }}
-      RABBITMQ_USER: ${{ secrets.RABBITMQ_USER }}
-      RABBITMQ_PASS: ${{ secrets.RABBITMQ_PASS }}
-      RABBITMQ_VIRTUAL_HOST: ${{ secrets.RABBITMQ_VIRTUAL_HOST }}
+      SERVICE_NAME: ACTIVITY
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The build job was injecting DB credentials, PATIENT_BE_ORIGIN, USER_BE_ORIGIN, and RabbitMQ secrets into the unit test environment. This caused 12 tests that call get_patient_name() (unmocked) to hang for 75s each waiting for an OS TCP timeout, adding ~15 min to CI.

Unit tests are fully mocked and require no external service credentials. Only SERVICE_NAME is needed for app initialisation.